### PR TITLE
Ezra/get summary

### DIFF
--- a/compend/bot.py
+++ b/compend/bot.py
@@ -1,8 +1,11 @@
 # __main__
+from typing import Coroutine
 import discord
 import redis
 from discord.ext import commands
 import logging
+from functools import wraps
+
 
 import utils.logging as lg
 from handler.settings import COMPEND_DISCORD_TOKEN, REDIS_PASSPHRASE
@@ -15,14 +18,29 @@ lg.attach_stdout_handler(logger)
 intents = discord.Intents.default()
 intents.message_content = True
 bot = commands.Bot(case_insensitive=True, intents=intents)
+pages = bot.create_group(
+    name="page", description="Commands relating to managing Notion pages"
+)
 
 redis_client = redis.Redis(password=REDIS_PASSPHRASE, decode_responses=True)
 manager = state_management.StateManager(client=redis_client)
 
 
+def deferring_command(func: Coroutine):
+    
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        if isinstance(args[0], discord.ApplicationContext):
+            await args[0].interaction.response.defer()
+        await func(*args, **kwargs)
+    return wrapper
+
+
 @bot.event
 async def on_ready() -> None:
-    logger.info(f"Logged in as {bot.user} (ID: {bot.user.id})")
+    logger.info(
+        f"Logged in as {bot.user} (ID: {bot.user.id}) on {len(bot.guilds)} guild(s)"
+    )
 
 
 @bot.slash_command(name="ping", description="Sends the bot's latency.")
@@ -33,10 +51,11 @@ async def ping(
     await ctx.respond(f"Pong! Latency is {bot.latency}")
 
 
-@bot.slash_command(
+@pages.command(
     name="home",
     description="Set the home page with a url.  Invoking without an argument will ask for the current home page title",
 )
+@deferring_command
 async def home_page(ctx: discord.ApplicationContext, target_url: str = "") -> None:
     if not target_url:
         await library.get_home_title(ctx, manager)
@@ -44,7 +63,7 @@ async def home_page(ctx: discord.ApplicationContext, target_url: str = "") -> No
     await library.target_note_home(ctx, manager, target_url)
 
 
-@bot.slash_command(
+@pages.command(
     name="session",
     description="Pick a session note page.  Requires the home page to be set.",
 )
@@ -54,10 +73,22 @@ async def session_page(ctx: discord.ApplicationContext) -> None:
 
 @bot.slash_command(
     name="current_session",
-    description="Get info from current session.  /current_session help to list available options",
+    description="Get info from current session.  Defaults to session number and title.",
+    options=[
+        discord.Option(
+            name="full",
+            type=str,
+            default=False,
+            description="Include full summary",
+            choices=[
+                discord.OptionChoice(name="Yes", value="1"),
+                discord.OptionChoice(name="No", value=""),
+            ]
+        )
+    ],
 )
-async def current_session(ctx: discord.ApplicationContext, property: str) -> None:
-    await library.get_session_title(ctx, manager)
+async def current_session(ctx: discord.ApplicationContext, full_info: str) -> None:
+    await library.get_session_info(ctx, manager, bool(full_info))
 
 
 if __name__ == "__main__":

--- a/compend/bot.py
+++ b/compend/bot.py
@@ -27,12 +27,12 @@ manager = state_management.StateManager(client=redis_client)
 
 
 def deferring_command(func: Coroutine):
-    
     @wraps(func)
     async def wrapper(*args, **kwargs):
         if isinstance(args[0], discord.ApplicationContext):
             await args[0].interaction.response.defer()
         await func(*args, **kwargs)
+
     return wrapper
 
 
@@ -83,7 +83,7 @@ async def session_page(ctx: discord.ApplicationContext) -> None:
             choices=[
                 discord.OptionChoice(name="Yes", value="1"),
                 discord.OptionChoice(name="No", value=""),
-            ]
+            ],
         )
     ],
 )

--- a/compend/handler/library.py
+++ b/compend/handler/library.py
@@ -89,17 +89,21 @@ async def target_note_home(
         await emoji_reply(ctx, str(ue), MessageType.FAIL, ["🔤"])
 
 
-
-
-async def get_session_info(ctx: ApplicationContext, manager: StateManager, full_info: bool) -> None:
+async def get_session_info(
+    ctx: ApplicationContext, manager: StateManager, full_info: bool
+) -> None:
     """
     Attempts to retrieve summary info of the note session page.
     """
     session_page = await manager.get_page(ctx.guild_id, "session")
     if not session_page:
-        await emoji_reply(ctx, "No session set.  Need to specify a session page via /page session.", MessageType.FAIL)
+        await emoji_reply(
+            ctx,
+            "No session set.  Need to specify a session page via /page session.",
+            MessageType.FAIL,
+        )
         return
-    
+
     if not full_info:
         await emoji_reply(
             ctx,
@@ -110,7 +114,9 @@ async def get_session_info(ctx: ApplicationContext, manager: StateManager, full_
     children = await notion.get_children(session_page.id)
     elements = children.get_all_under_header("Summary")
     text_content = [e.paragraph.text_content for e in elements]
-    embed = Embed(type='rich', title=session_page.page_title, description=text_content[0])
+    embed = Embed(
+        type="rich", title=session_page.page_title, description=text_content[0]
+    )
     await ctx.respond(embed=embed)
 
 

--- a/compend/handler/state_management.py
+++ b/compend/handler/state_management.py
@@ -40,7 +40,7 @@ class StateManager:
         guild_state = self.states[guild_id]
         guild_state.update({page_name: page_object})
         self.client.set(f"{guild_id}:{page_name}", page_object.id)
-        logger.info("Saved page {guild_id}:{page_name}")
+        logger.info(f"Saved page {guild_id}:{page_name}")
 
     def get_from_state(self, guild_id: str, page_name: str) -> PageObject:
         """

--- a/compend/notion/data_types/data_classes.py
+++ b/compend/notion/data_types/data_classes.py
@@ -17,16 +17,16 @@ class RichTextObject(BaseModel):
 
 
 class TextContentMixin(BaseModel):
-    
+
     rich_text: List[RichTextObject]
-    color: str 
-    
+    color: str
+
     @property
     def text_content(self) -> str:
         content = "".join(t.plain_text for t in self.rich_text)
-        return unicodedata.normalize('NFKD', content)
-    
-    
+        return unicodedata.normalize("NFKD", content)
+
+
 class PropertyObject(BaseModel):
     id: str
     type: PropertyType
@@ -38,14 +38,18 @@ class TitleObject(PropertyObject):
     def get_full_title(self) -> str:
         return "".join([t.plain_text for t in self.title])
 
+
 class HeadingObject(TextContentMixin):
     is_toggleable: bool
-    
+
+
 class ParagraphObject(TextContentMixin):
     children: Optional[List["BlockObject"]]
-    
+
+
 class ChildPageObject(BaseModel):
     title: str
+
 
 class BlockObject(BaseModel):
     object: str = "block"
@@ -57,10 +61,11 @@ class BlockObject(BaseModel):
     heading_2: Optional[HeadingObject]
     heading_3: Optional[HeadingObject]
     paragraph: Optional[ParagraphObject]
-    
+
     @property
     def active_heading(self):
         return self.heading_1 or self.heading_2 or self.heading_3 or None
+
 
 class PageObject(BaseModel):
     object: str = "page"

--- a/compend/notion/data_types/response_object_classes.py
+++ b/compend/notion/data_types/response_object_classes.py
@@ -1,7 +1,6 @@
 from typing import List
 from pydantic import BaseModel
-
-from notion.data_types.data_classes import BlockObject, ChildPageObject
+from notion.data_types.data_classes import BlockObject
 
 
 class ChildrenResponseObject(BaseModel):
@@ -9,6 +8,24 @@ class ChildrenResponseObject(BaseModel):
     results: List[BlockObject]
     has_more: bool
     type: str = "block"
-
+    
+    
+    def get_all_under_header(self, heading_name: str) -> List[BlockObject]:
+        """
+        Retrieves all block objects that are under a header in the page
+        TODO: Depending on how many search and access methods we'll need, it'll be worth to heapify the result content.
+        """
+        headers = iter((idx, r) for (idx, r) in enumerate(self.results) if r.active_heading)
+        for h in headers:
+            if heading_name.lower() in h[1].active_heading.text_content.lower():
+                start_index = h[0] + 1
+                try:
+                    # collect all the following elements
+                    next_h = next(headers)
+                    return self.results[start_index:next_h[0]]
+                except StopIteration:
+                    return self.results[start_index:]
+        return []
+    
 
 __all__ = ["ChildrenResponseObject"]

--- a/compend/notion/data_types/response_object_classes.py
+++ b/compend/notion/data_types/response_object_classes.py
@@ -8,24 +8,25 @@ class ChildrenResponseObject(BaseModel):
     results: List[BlockObject]
     has_more: bool
     type: str = "block"
-    
-    
+
     def get_all_under_header(self, heading_name: str) -> List[BlockObject]:
         """
         Retrieves all block objects that are under a header in the page
         TODO: Depending on how many search and access methods we'll need, it'll be worth to heapify the result content.
         """
-        headers = iter((idx, r) for (idx, r) in enumerate(self.results) if r.active_heading)
+        headers = iter(
+            (idx, r) for (idx, r) in enumerate(self.results) if r.active_heading
+        )
         for h in headers:
             if heading_name.lower() in h[1].active_heading.text_content.lower():
                 start_index = h[0] + 1
                 try:
                     # collect all the following elements
                     next_h = next(headers)
-                    return self.results[start_index:next_h[0]]
+                    return self.results[start_index : next_h[0]]
                 except StopIteration:
                     return self.results[start_index:]
         return []
-    
+
 
 __all__ = ["ChildrenResponseObject"]


### PR DESCRIPTION
The /current_session command now has an argument for retrieving summary info:
<img width="907" alt="Screenshot 2023-01-29 at 10 07 07 PM" src="https://user-images.githubusercontent.com/14167519/215385557-107b78ea-35c5-4956-b442-719a148296fa.png">
Using this option will pull the paragraph info from underneath the "Summary" header.  For now, this only pulls a single paragraph.
<img width="635" alt="Screenshot 2023-01-29 at 10 07 18 PM" src="https://user-images.githubusercontent.com/14167519/215385594-91d5bb7e-dece-4ffb-a704-75313b1e2112.png">
